### PR TITLE
Added parsing of define/contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,36 @@ Hosts files for the original 430 Loot compiler
 
 # moot/
 
-Hosts files for a gradually typed compiler built using coercions
+Hosts files for compiler with function contracts
+
+## Instructions:
+To open the Racket IDE:
+```
+cd moot
+racket
+```
+
+### Parsing:
+To test parsing, first modify `example.rkt` with desired code. Then, inside the racket IDE:
+
+```
+(require "parse-file.rkt")
+
+(main "example.rkt")
+```
+
+### Compiling:
+To test compilation, first modify `example.rkt` with desired code. Then, inside the racket IDE, run the following:
+
+```
+(require "compile-file.rkt")
+
+(main "example.rkt")
+```
+
+### Testing:
+To run the test suite:
+```
+cd moot/test
+racket compile.rkt
+```

--- a/moot/ast.rkt
+++ b/moot/ast.rkt
@@ -7,6 +7,11 @@
 ;; type Defn = (Defn Id (Listof Id) Expr)
 (struct Defn (f xs e) #:prefab)
 
+;; type DefnContract = (DefnContract Defn (Listof Id) Id)
+
+;; contract-expr is a list of variables pointing to functions. These functions must be 1-ary and return Bool
+(struct DefnContract (defn contract-list ret-contract) #:prefab)
+
 ;; type Expr = (Eof)
 ;;           | (Empty)
 ;;           | (Int Integer)

--- a/moot/test/test-runner.rkt
+++ b/moot/test/test-runner.rkt
@@ -286,7 +286,13 @@
                      '(tri 36))
                 666)
   (check-equal? (run '((match 8 [8 (lambda (x) x)]) 12))
-                12))
+                12)
+                
+   ;; Moot examples
+   (check-equal? (run '(define/contract (furlongs->feet fr) (-> integer? integer?) (* 660 fr)) '(furlongs->feet "not a furlong")) 'err)
+)
+
+
 
 (define (test-runner-io run)
   ;; Evildoer examples


### PR DESCRIPTION
* Added information about testing to `README`
* Added DefnContract struct in `ast.rkt`. We currently only support one predicate per parameter / return value

`(DefnContract Defn (Listof Id) Id) : `

> Defn stores function definition
> Listof Id stores predicates for each function parameter
> Id stores predicate for return value

* Added parsing of (define/contract (fun var) (predicate-list) (body)) into `parse.rkt`. Parsing is only successful if there is one predicate per parameter / return value

TODO:
1. Check that all var's are actually Procs
2. Figure out validate that functions in the contract-expr truly are predicates at compile-time
3. Add support for multiple function contracts per variable
4. Add support for nested predicate functions i.e. (not (zero?))