### PR TITLE
Add parsing for Higher Order Functions

### DIFF
--- a/pact/ast.rkt
+++ b/pact/ast.rkt
@@ -10,10 +10,13 @@
 ;; type Defn = (Defn Id Lambda)
 (struct Defn (f l) #:prefab)
 
-;; type DefnContract = (DefnContract Defn (Listof Id) Id)
+;; type DefnContract = (DefnContract Defn (Listof Predicate) Predicate)
 
 ;; contract-expr is a list of variables pointing to functions. These functions must be 1-ary and return Bool
 (struct DefnContract (defn contract-list ret-contract) #:prefab)
+
+;; type Predicate = (Id)
+;;                | (Listof Predicate)
 
 ;; type Expr   = (Eof)
 ;;             | (Quote Datum)

--- a/pact/parse.rkt
+++ b/pact/parse.rkt
@@ -69,18 +69,26 @@
      (match (parse-e e)
        [e (list (Defn x e))])]
     [(list 'define/contract (cons f xs) (cons '-> vs) e)
-     (match (parse-param-list xs e)
+    (let ((ps (map parse-predicate vs)))
+      (match (parse-param-list xs e)
         [(Lam l xs e)
-          (match (extract-last vs)
+          (match (extract-last ps)
             [(cons a b)   
-             (if (and (andmap symbol? xs) (andmap symbol? vs) (= (length a) (length xs)))
+             (if (and (andmap symbol? xs) (= (length a) (length xs)))
                  (list (DefnContract (Defn f (Lam l xs e)) a (car b))) 
-                 (error "parse definition error"))])]
+                 (error "parse define/contract error"))])]
         [(LamRest l xs x e)
-           (error "parse definition error")])] ; Contracts currently do not support rest-arguements
+           (error "parse definition error")]))] ; Contracts currently do not support rest-arguements
     [(cons 'struct _)
      (parse-struct s)]
     [_ (error "Parse defn error" s)]))
+
+  ;; S-Expr -> Predicate
+(define (parse-predicate v)
+  (match v
+    [(cons '-> p)
+      (map parse-predicate p)]
+    [x (if (symbol? x) x (error "parse predicate error"))]))
 
   ;; S-Expr -> [Listof Defn]
 (define (parse-struct s)


### PR DESCRIPTION
* Redefined `(DefnContract Defn (Listof Id) Id)` to `(DefnContract Defn (Listof Predicate) Predicate)` where Predicate is defined as:
> Predicate := Id 
>                      (List of Predicate)

* Added parsing of higher order contracts in `parse.rkt`
