### PR TITLE
High Order Contracts Expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.s
 *.S
 *~
+*.bak
 **/compiled
 pact/compiled

--- a/pact/parse-utils.rkt
+++ b/pact/parse-utils.rkt
@@ -1,0 +1,13 @@
+#lang racket
+(provide extract-last)
+
+;; [Listof T] -> T 
+(define (extract-last xs)
+  (match xs
+    ['() (raise "no last element")]
+    [(cons x xs) #:when (empty? xs)
+                 (list '() x)]
+    [(cons x xs)
+     (let ([ys (extract-last xs)])
+       (list (cons x (car ys)) (car (cdr ys)))
+    )]))

--- a/pact/parse.rkt
+++ b/pact/parse.rkt
@@ -1,6 +1,6 @@
 #lang racket
 (provide parse parse-define parse-e parse-library)
-(require "stdlib.rkt" "ast.rkt")
+(require "stdlib.rkt" "ast.rkt" "utils.rkt" "parse-utils.rkt")
 
 ;; [Listof S-Expr] -> Prog
 (define (parse s)
@@ -381,13 +381,3 @@
 
 (define (drop-% x)
   (string->symbol  (substring (symbol->string x) 1)))
-
-(define (extract-last xs)
-  (match xs
-    ['() (raise "no last element")]
-    [(cons x xs) #:when (empty? xs)
-                 (list '() x)]
-    [(cons x xs)
-     (let ([ys (extract-last xs)])
-       (list (cons x (car ys)) (car (cdr ys)))
-    )]))

--- a/pact/remove-contracts.rkt
+++ b/pact/remove-contracts.rkt
@@ -32,10 +32,10 @@
     (Defn f (Lam g xs out-expr))))
 
 ; expr Predicate -> expr
-(define (expand-outcontract expr out) (begin (print out)
+(define (expand-outcontract expr out)
   (let ([label (gensym "out")])
     ; Assign new variable to expression output and expand the out contract
-    (Let (list label) (list expr) (expand-contract label out expr)))))
+    (Let (list label) (list expr) (expand-contract label out expr))))
 
 ; id Predicate expr
 (define (expand-contract x c expr)
@@ -79,4 +79,4 @@
 (define (n-syms n [label ""])
   (match n
     [0 '()]
-    [n (cons (Var (gensym label)) (n-syms (sub1 n) label))]))
+    [n (cons (gensym label) (n-syms (sub1 n) label))]))

--- a/pact/remove-contracts.rkt
+++ b/pact/remove-contracts.rkt
@@ -41,14 +41,14 @@
     (Let (list label) (list expr) (expand-contract label out expr))))
 
 ; id Predicate expr
-(define (expand-contract x contract expr)
-  (match contract
-    [(list _ ...) (expand-higher-contract x contract expr)]
+(define (expand-contract x c expr)
+  (match c
+    [(list _ ...) (expand-higher-contract x c expr)]
     [pred (If (App (Var pred) (list (Var x))) expr (errorast "you"))]))
 
 ; id (Listof Predicate) expr -> expr
-(define (expand-higher-contract x contracts expr)
-  (match (extract-last contracts)
+(define (expand-higher-contract x cs expr)
+  (match (extract-last cs)
     [(cons ins out)
      ; Get variables for the lambda
      (let ([syms (n-syms (length ins) "hcon")])

--- a/pact/remove-contracts.rkt
+++ b/pact/remove-contracts.rkt
@@ -1,5 +1,5 @@
 #lang racket
-(provide remove-contracts expand-defcontract)
+(provide remove-contracts)
 (require "ast.rkt"
          "env.rkt"
          "parse-utils.rkt")

--- a/pact/remove-contracts.rkt
+++ b/pact/remove-contracts.rkt
@@ -35,7 +35,7 @@
 (define (expand-outcontract expr out)
   (let ([label (gensym "out")])
     ; Assign new variable to expression output and expand the out contract
-    (Let (list label) (list expr) (expand-contract label out expr))))
+    (Let (list label) (list expr) (expand-contract label out (Var label)))))
 
 ; id Predicate expr
 (define (expand-contract x c expr)

--- a/pact/test/test-runner.rkt
+++ b/pact/test/test-runner.rkt
@@ -695,14 +695,33 @@
   (check-equal? (run '(define/contract (bake flavor) (-> string? string?)
   #t)'(bake "apple")) 'err)
 
+  ; Good 1 level high order contract
   (check-equal? (run '(define/contract (bake flavor) (-> (-> string? integer?) integer?)
                      (* 2 (flavor "hello world")))'(bake string-length)) 22) 
 
+  ; Bad function output on high order contract
   (check-equal? (run '(define/contract (bake flavor) (-> (-> string? integer?) integer?)
                      (* 2 (flavor "hello world")))'(bake string->list)) 'err) 
   
+  ; Bad function input on high order contract
   (check-equal? (run '(define/contract (bake flavor) (-> (-> string? integer?) integer?)
                      (* 2 (flavor "hello world")))'(bake integer->char)) 'err) 
+  
+  ; Good 2 level high order contract
+  (check-equal? (run '(define (foo x y) (+ x (y "hello world")))'(define/contract (bake flavor) (-> (-> integer? (-> string? integer?) integer?) integer?)
+                     (flavor 10 string-length))'(bake foo)) 21) 
+
+  ; Bad function for high order contract
+  (check-equal? (run '(define/contract (bake flavor) (-> (-> integer? (-> string? integer?) integer?) integer?)
+                     (flavor 10 string-length))'(bake string-length)) 'err) 
+
+  ; Bad input to first high order contract 
+  (check-equal? (run '(define (foo x y) (+ x (y "hello world")))'(define/contract (bake flavor) (-> (-> integer? (-> string? integer?) integer?) integer?)
+                     (flavor "apple" string-length))'(bake foo)) 'err) 
+
+  ; Bad input to second high order contract
+  (check-equal? (run '(define (foo x y) (+ x (y 1)))'(define/contract (bake flavor) (-> (-> integer? (-> string? integer?) integer?) integer?)
+                     (flavor 10 string-length))'(bake foo)) 'err) 
 )
 
 

--- a/pact/test/test-runner.rkt
+++ b/pact/test/test-runner.rkt
@@ -695,9 +695,14 @@
   (check-equal? (run '(define/contract (bake flavor) (-> string? string?)
   #t)'(bake "apple")) 'err)
 
-  (check-equal? (run '(define/contract (bake flavor) (-> (-> string? int?) string?)
+  (check-equal? (run '(define/contract (bake flavor) (-> (-> string? integer?) integer?)
                      (* 2 (flavor "hello world")))'(bake string-length)) 22) 
+
+  (check-equal? (run '(define/contract (bake flavor) (-> (-> string? integer?) integer?)
+                     (* 2 (flavor "hello world")))'(bake string->list)) 'err) 
   
+  (check-equal? (run '(define/contract (bake flavor) (-> (-> string? integer?) integer?)
+                     (* 2 (flavor "hello world")))'(bake integer->char)) 'err) 
 )
 
 

--- a/pact/test/test-runner.rkt
+++ b/pact/test/test-runner.rkt
@@ -694,6 +694,9 @@
 
   (check-equal? (run '(define/contract (bake flavor) (-> string? string?)
   #t)'(bake "apple")) 'err)
+
+  (check-equal? (run '(define/contract (bake flavor) (-> (-> string? int?) string?)
+                     (* 2 (flavor "hello world")))'(bake string-length)) 22) 
   
 )
 


### PR DESCRIPTION
Implements expansion functionality for higher order contracts. These changes break the previous *blame* system as there is now only one point where blame is emitted, which will currently always blame `"you"`. 

It should be fairly straightforward to implement blame for high order contracts by passing a boolean variable through the recursive calls (which flips at each recursion level) that is used to determine who to blame.